### PR TITLE
Add upper version limit for Pydantic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def get_version() -> str:
 
 def get_install_requires():
     return [
-        "pydantic>=1.10.2",
+        "pydantic>=1.10.2,<2",
         "rich>=13.4.2",
         "typer>=0.6.1",
     ]


### PR DESCRIPTION
`grafana_dashboard_python` is not compatible with Pydantic v2, so we need to add an upper version limit to prevent it from being installed.

Issue: https://github.com/fzyzcjy/grafana_dashboard_python/issues/1